### PR TITLE
try: downgrade rsa package after awscli installation

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,7 +14,7 @@ jobs:
             pip install --upgrade awscli
             # downgrade rsa
             pip uninstall -y rsa
-            pip install -v rsa==4.3
+            pip install rsa==4.3
       - run:
           name: Confirm package version
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,6 +12,9 @@ jobs:
           command: |
             pip install futures
             pip install --upgrade awscli
+            # downgrade rsa
+            pip uninstall -y rsa
+            pip install -v rsa==4.3
       - run:
           name: Confirm package version
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,7 +14,7 @@ jobs:
             pip install --upgrade awscli
             # downgrade rsa
             pip uninstall -y rsa
-            pip install rsa==4.3
+            pip install "rsa<=4.3"
       - run:
           name: Confirm package version
           command: |


### PR DESCRIPTION
#### description

This PR attempts to downgrade the `rsa` Python package version to <= 4.3 since [this is the last version to support Python 2.7.](https://github.com/grpc/grpc/issues/23190#issuecomment-643409920)

> `rsa` is a dependency from `awscli` package. 
> CircleCI machine builds comes pre-installed with the deprecated Python 2.7 runtime.